### PR TITLE
Remove native autocomplete

### DIFF
--- a/awesomplete.js
+++ b/awesomplete.js
@@ -13,6 +13,7 @@ var _ = function (input, o) {
 	// Setup
 
 	this.input = $(input);
+	this.input.setAttribute("autocomplete", "off");
 	this.input.setAttribute("aria-autocomplete", "list");
 
 	o = o || {};


### PR DESCRIPTION
Because it overlays the ul while being unreachable using the keyboard.
